### PR TITLE
some launch files are ended with ".xml"

### DIFF
--- a/haros/metamodel.py
+++ b/haros/metamodel.py
@@ -687,7 +687,7 @@ class SourceFile(SourceObject):
     PYTHON = 'python script'
     PYTHON_ALT = '.py'
     PKG_XML = 'package.xml'
-    LAUNCH = ('.launch', '.launch.xml')
+    LAUNCH = ('.launch', '.launch.xml', '.xml')
     MSG = '.msg'
     SRV = '.srv'
     ACTION = '.action'
@@ -774,10 +774,10 @@ class SourceFile(SourceObject):
                 return 'cpp'
             if self.name.endswith(self.PYTHON_ALT):
                 return 'python'
-        if self.name.endswith(self.LAUNCH):
-            return 'launch'
         if self.name == self.PKG_XML:
             return 'package'
+        if self.name.endswith(self.LAUNCH):
+            return 'launch'
         if self.name.endswith(self.MSG):
             return 'msg'
         if self.name.endswith(self.SRV):


### PR DESCRIPTION
For example, in [mir_robot](https://github.com/dfki-ric/mir_robot#user-content-gazebo-demo-mapping), they have a launch file called `move_base.xml`

To include them in the database, add `.xml` as one of the launch extensions, and move the match of launch files after package.xml files so that package.xml files can be correctly matched